### PR TITLE
Enforce knex version to 0.5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/p-baleine/grunt-knex-migrate/issues"
   },
   "dependencies": {
-    "knex": "git+https://github.com/tgriesser/knex.git",
+    "knex": "~0.5.15",
     "bluebird": "~0.11.4-1",
     "colors": "~0.6.2"
   },


### PR DESCRIPTION
Latest `knex` (0.6.x) somehow doesn't play well so we need to make sure we're using 0.5.x I didn't have much time to investigate, but it cannot find migrations where they really are. I rolled back to 0.5.x and it helped.

P.S. We probably should move it to `peerDependencies` and do not use/keep local copy.
