### PR TITLE
Updates dependencies & fixes tests

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -8,5 +8,8 @@
   "boss": true,
   "eqnull": true,
   "node": true,
-  "latedef": false
+  "latedef": false,
+  "globals": {
+    "Promise": true
+  }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"
+  - "0.12"
+  - "iojs"
 before_script:
   - npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "grunt-knex-migrate",
   "version": "0.0.2",
   "description": "Grunt task for knex's migrate",
-  "main": "index.js",
   "scripts": {
     "test": "grunt test"
   },
@@ -24,22 +23,23 @@
     "url": "https://github.com/p-baleine/grunt-knex-migrate/issues"
   },
   "dependencies": {
-    "knex": "git+https://github.com/tgriesser/knex.git",
-    "bluebird": "~0.11.4-1",
+    "knex": "~0.7.3",
+    "bluebird": "~2.6.2",
     "colors": "~0.6.2"
   },
   "devDependencies": {
-    "grunt": "~0.4.2",
-    "grunt-contrib-jshint": "~0.7.2",
-    "grunt-mocha-cli": "~1.3.0",
+    "grunt": "~0.4.5",
+    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-mocha-cli": "~1.11.0",
     "matchdep": "~0.3.0",
-    "sqlite3": "~2.1.19",
-    "chai": "~1.8.1",
-    "glob": "~3.2.7",
-    "grunt-contrib-clean": "~0.5.0",
-    "grunt-mkdir": "~0.1.1"
+    "sqlite3": "~3.0.4",
+    "chai": "~1.10.0",
+    "glob": "~4.3.2",
+    "grunt-contrib-clean": "~0.6.0",
+    "grunt-mkdir": "~0.1.2"
   },
   "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": "~0.4.0",
+    "knex": "~0.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,15 +28,16 @@
     "colors": "~0.6.2"
   },
   "devDependencies": {
-    "grunt": "~0.4.5",
-    "grunt-contrib-jshint": "~0.10.0",
-    "grunt-mocha-cli": "~1.11.0",
-    "matchdep": "~0.3.0",
-    "sqlite3": "~3.0.4",
     "chai": "~1.10.0",
     "glob": "~4.3.2",
+    "grunt": "~0.4.5",
     "grunt-contrib-clean": "~0.6.0",
-    "grunt-mkdir": "~0.1.2"
+    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-mkdir": "~0.1.2",
+    "grunt-mocha-cli": "~1.11.0",
+    "matchdep": "~0.3.0",
+    "mocha-jshint": "0.0.9",
+    "sqlite3": "~3.0.4"
   },
   "peerDependencies": {
     "grunt": "~0.4.0",

--- a/test/function.json
+++ b/test/function.json
@@ -1,10 +1,12 @@
 {
   "directory": "./test/tmp/function/db/migrate",
-  "tableName": "knex_migrations_for_function",
   "database": {
     "client": "sqlite3",
     "connection": {
       "filename": "./test/tmp/function/db/function.db"
+    },
+    "migrations": {
+      "tableName": "knex_migrations_for_function"
     }
   }
 }

--- a/test/jshint.spec.js
+++ b/test/jshint.spec.js
@@ -1,0 +1,1 @@
+require('mocha-jshint')();

--- a/test/knex-migrate.test.js
+++ b/test/knex-migrate.test.js
@@ -1,3 +1,5 @@
+/*jshint expr: true, mocha: true*/
+
 var expect = require('chai').expect,
     knex = require('knex'),
     Promise = require('bluebird'),

--- a/test/knex-migrate.test.js
+++ b/test/knex-migrate.test.js
@@ -15,12 +15,7 @@ describe('knexmigrate task', function() {
   describe('config specified by simple object', function() {
     before(function() {
       this.definition = require('./simple');
-      this.conn = knex.initialize({
-        client: 'sqlite3',
-        connection: {
-          filename: __dirname + '/../' + this.definition.database.connection.filename
-        }
-      });
+      this.conn = knex(this.definition.database);
     });
 
     it('should create migration file at specified path.', promisify(function() {
@@ -30,7 +25,13 @@ describe('knexmigrate task', function() {
     }));
 
     it('should create migration table as specified name', promisify(function() {
-      return this.conn.schema.hasTable(this.definition.tableName).then(function(exists) {
+      var tableName = this.definition.database.migrations.tableName,
+          knex = this.conn;
+
+      // We call the currentVersion of the migrations to ensure table creation
+      return knex.migrate.currentVersion().then(function(version) {
+        return knex.schema.hasTable(tableName);
+      }).then(function(exists) {
         return exists ? Promise.resolve() : Promise.reject(new Error('table not exist'));
       });
     }));
@@ -39,12 +40,7 @@ describe('knexmigrate task', function() {
   describe('config specified by a staticfile', function() {
     before(function() {
       this.definition = require('./staticfile');
-      this.conn = knex.initialize({
-        client: 'sqlite3',
-        connection: {
-          filename: __dirname + '/../' + this.definition.database.connection.filename
-        }
-      });
+      this.conn = knex(this.definition.database);
     });
 
     it('should create migration file at specified path.', promisify(function() {
@@ -54,7 +50,13 @@ describe('knexmigrate task', function() {
     }));
 
     it('should create migration table as specified name', promisify(function() {
-      return this.conn.schema.hasTable(this.definition.tableName).then(function(exists) {
+      var tableName = this.definition.database.migrations.tableName,
+          knex = this.conn;
+
+      // We call the currentVersion of the migrations to ensure table creation
+      return knex.migrate.currentVersion().then(function(version) {
+        return knex.schema.hasTable(tableName);
+      }).then(function(exists) {
         return exists ? Promise.resolve() : Promise.reject(new Error('table not exist'));
       });
     }));
@@ -63,12 +65,7 @@ describe('knexmigrate task', function() {
   describe('config specified by a staticfile', function() {
     before(function() {
       this.definition = require('./function');
-      this.conn = knex.initialize({
-        client: 'sqlite3',
-        connection: {
-          filename: __dirname + '/../' + this.definition.database.connection.filename
-        }
-      });
+      this.conn = knex(this.definition.database);
     });
 
     it('should create migration file at specified path.', promisify(function() {
@@ -78,7 +75,13 @@ describe('knexmigrate task', function() {
     }));
 
     it('should create migration table as specified name', promisify(function() {
-      return this.conn.schema.hasTable(this.definition.tableName).then(function(exists) {
+      var tableName = this.definition.database.migrations.tableName,
+          knex = this.conn;
+
+      // We call the currentVersion of the migrations to ensure table creation
+      return knex.migrate.currentVersion().then(function(version) {
+        return knex.schema.hasTable(tableName);
+      }).then(function(exists) {
         return exists ? Promise.resolve() : Promise.reject(new Error('table not exist'));
       });
     }));

--- a/test/simple.json
+++ b/test/simple.json
@@ -1,10 +1,12 @@
 {
   "directory": "./test/tmp/simple/db/migrate",
-  "tableName": "knex_migrations",
   "database": {
     "client": "sqlite3",
     "connection": {
       "filename": "./test/tmp/simple/db/simple.db"
+    },
+    "migrations": {
+      "tableName": "knex_migrations"
     }
   }
 }

--- a/test/staticfile.json
+++ b/test/staticfile.json
@@ -1,10 +1,12 @@
 {
   "directory": "./test/tmp/staticfile/db/migrate",
-  "tableName": "knex_migrations_for_static_file",
   "database": {
     "client": "sqlite3",
     "connection": {
       "filename": "./test/tmp/staticfile/db/staticfile.db"
+    },
+    "migrations": {
+      "tableName": "knex_migrations_for_static_file"
     }
   }
 }


### PR DESCRIPTION
As the last PR was just for 'downgrading' the version, here is a fixed version.

Basically it calls `knex.migrate.currentVersion()` to ensure that the migrations table is created.

It also restructures the `*.json` fixtures, so that the `database` property matches `knex`'s expectations.

``` diff
- "tableName": "knex_migrations",
+ "migrations": {
+   "tableName": "knex_migrations"
+ }
```

As a side-effect I also enhanced the `jshint` functionality, as my linter showed 17 'errors' for `knex-migrate.test.js` 
