### PR TITLE
Update dependencies, fixing regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,18 +24,18 @@
     "url": "https://github.com/p-baleine/grunt-knex-migrate/issues"
   },
   "dependencies": {
-    "knex": "git+https://github.com/tgriesser/knex.git",
-    "bluebird": "~0.11.4-1",
-    "colors": "~0.6.2"
+    "knex": "^0.8.6",
+    "bluebird": "^3.1.1",
+    "colors": "^1.1.2"
   },
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-contrib-jshint": "~0.7.2",
-    "grunt-mocha-cli": "~1.3.0",
-    "matchdep": "~0.3.0",
-    "sqlite3": "~2.1.19",
-    "chai": "~1.8.1",
-    "glob": "~3.2.7",
+    "grunt-mocha-cli": "^2.0.0",
+    "matchdep": "^1.0.0",
+    "sqlite3": "^3.1.0",
+    "chai": "^3.4.1",
+    "glob": "^6.0.0",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-mkdir": "~0.1.1"
   },


### PR DESCRIPTION
The migration API changed in version 0.9.0, causing
the migrate:latest task to fail. This sets an
explicit dependency on the last 0.8.x version.

Also updated a few other dependencies in order to
make grunt test work on Node 4.x

The tests fail, but I have no idea why, or if they
have ever passed.
