### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,19 +24,19 @@
     "url": "https://github.com/p-baleine/grunt-knex-migrate/issues"
   },
   "dependencies": {
-    "knex": "git+https://github.com/tgriesser/knex.git",
-    "bluebird": "~0.11.4-1",
-    "colors": "~0.6.2"
+    "knex": "0.9.0",
+    "bluebird": "~3.1.1",
+    "colors": "~1.1.2"
   },
   "devDependencies": {
     "grunt": "~0.4.2",
-    "grunt-contrib-jshint": "~0.7.2",
-    "grunt-mocha-cli": "~1.3.0",
-    "matchdep": "~0.3.0",
-    "sqlite3": "~2.1.19",
-    "chai": "~1.8.1",
-    "glob": "~3.2.7",
-    "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-jshint": "~0.12.0",
+    "grunt-mocha-cli": "~2.0.0",
+    "matchdep": "~1.0.0",
+    "sqlite3": "~3.1.1",
+    "chai": "~3.4.1",
+    "glob": "~6.0.4",
+    "grunt-contrib-clean": "~0.7.0",
     "grunt-mkdir": "~0.1.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
#####  Problem:

Current packages fail in many installations with the latest versions of node (node v0.12 and v4). They also fail if knex<0.9.0 is used.
#####  Solution:

Upgrade dependencies

I've also added an npm link on the `knex` package, to allow locking to a specific version.
