### PR TITLE
Require any version of knex as a peer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "url": "https://github.com/p-baleine/grunt-knex-migrate/issues"
   },
   "dependencies": {
-    "knex": "git+https://github.com/tgriesser/knex.git",
     "bluebird": "~0.11.4-1",
     "colors": "~0.6.2"
   },
@@ -40,6 +39,7 @@
     "grunt-mkdir": "~0.1.1"
   },
   "peerDependencies": {
+    "knex": "git+https://github.com/tgriesser/knex.git",
     "grunt": "~0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "grunt-mkdir": "~0.1.1"
   },
   "peerDependencies": {
-    "knex": "git+https://github.com/tgriesser/knex.git",
+    "knex": ">0.0.0",
     "grunt": "~0.4.0"
   }
 }


### PR DESCRIPTION
This moves the knex dependency to the list of peer dependencies as:
- The current dependency points at the latest version of knex in github, rather than a specific commit or release number, causing installations to fail sometimes, unpredictably.
- grunt-knex-migrate is necessarily always used together with knex, so that knex is preferable as it is going to be compatible with the rest of the code.

Ref: Peer dependencies: https://nodejs.org/en/blog/npm/peer-dependencies/
Note: Unfortunately this requires specifying an npm version number, afaik, so I have made the version requirement as liberal as possible: 0.0.0 and above.
Note: Currently many other grunt plugins place peer dependencies under devDependencies.  See: http://gruntjs.com/#plugins-all
